### PR TITLE
Make thralls uncommon

### DIFF
--- a/packs/impossible-playtest-thralls/Conglomerate_of_Limbs_Xuy2zf3qpsmm8wbb.json
+++ b/packs/impossible-playtest-thralls/Conglomerate_of_Limbs_Xuy2zf3qpsmm8wbb.json
@@ -219,7 +219,7 @@
       "value": [
         "undead"
       ],
-      "rarity": "common",
+      "rarity": "uncommon",
       "size": {
         "value": "huge"
       }

--- a/packs/impossible-playtest-thralls/Living_Graveyard_CN6TMEeEd0Wmvkct.json
+++ b/packs/impossible-playtest-thralls/Living_Graveyard_CN6TMEeEd0Wmvkct.json
@@ -215,7 +215,7 @@
       "value": [
         "undead"
       ],
-      "rarity": "common",
+      "rarity": "uncommon",
       "size": {
         "value": "grg"
       }

--- a/packs/impossible-playtest-thralls/Perfected_Thrall_SX5QACMD5SvH9oeZ.json
+++ b/packs/impossible-playtest-thralls/Perfected_Thrall_SX5QACMD5SvH9oeZ.json
@@ -219,7 +219,7 @@
       "value": [
         "undead"
       ],
-      "rarity": "common",
+      "rarity": "uncommon",
       "size": {
         "value": "med"
       }

--- a/packs/impossible-playtest-thralls/Recurring_Nightmare_uu7VA9eIwi1tUZVs.json
+++ b/packs/impossible-playtest-thralls/Recurring_Nightmare_uu7VA9eIwi1tUZVs.json
@@ -224,7 +224,7 @@
       "value": [
         "undead"
       ],
-      "rarity": "common",
+      "rarity": "uncommon",
       "size": {
         "value": "med"
       }

--- a/packs/impossible-playtest-thralls/Skeletal_Lancer_d1333zUKqydfJM9b.json
+++ b/packs/impossible-playtest-thralls/Skeletal_Lancer_d1333zUKqydfJM9b.json
@@ -219,7 +219,7 @@
       "value": [
         "undead"
       ],
-      "rarity": "common",
+      "rarity": "uncommon",
       "size": {
         "value": "med"
       }

--- a/packs/impossible-playtest-thralls/Thrall_ISmLeI8zNc6YWysQ.json
+++ b/packs/impossible-playtest-thralls/Thrall_ISmLeI8zNc6YWysQ.json
@@ -219,7 +219,7 @@
       "value": [
         "undead"
       ],
-      "rarity": "common",
+      "rarity": "uncommon",
       "size": {
         "value": "med"
       }


### PR DESCRIPTION
They are all created by uncommon spells so they should also be uncommon. 
This matters since summon undead only allows summoning common creatures and `pf2e-summon-assist` allows them to be summoned otherwise.